### PR TITLE
fixed plural terms when a unique parameter is passed.

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -52,12 +52,12 @@ class Bootstrap
     /**
      * Recebe os valores das rotas.
      *
-     * @param $routes string
+     * @param $route string
      * @param $callback string
      */
-    public static function setRoutes($routes, $callback, $type)
+    public static function addRoute($route, $callback, $type)
     {
-        self::$routes[] = ['route' => $routes, 'callback' => $callback, 'type' => $type];
+        self::$routes[] = ['route' => $route, 'callback' => $callback, 'type' => $type];
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -13,9 +13,9 @@ class Route
      *
      * @param array $post
      */
-    public static function post($routes, $callback)
+    public static function post($route, $callback)
     {
-        Bootstrap::setRoutes($routes, $callback, 'POST');
+        Bootstrap::addRoute($route, $callback, 'POST');
     }
 
     /**
@@ -25,7 +25,7 @@ class Route
      */
     public static function get($route, $callback)
     {
-        Bootstrap::setRoutes($route, $callback, 'GET');
+        Bootstrap::addRoute($route, $callback, 'GET');
     }
 
     /**


### PR DESCRIPTION
Olá amigo, fui dar uma lida no seu código de curioso, ao ler ele fiquei em dúvida em um método, a proposta que faço abaixo facilitaria a leitura e deixaria mais coeso com sua funcionalidade

O método que antes era chamado de ```setRoutes``` na realidade estava adicionando uma rota na propriedade da classe através de um novo índice no array, com isso acredito que o melhor termo seria ```addRoute``` e sem o plural, tanto no método quanto nas variáveis.